### PR TITLE
ignore empty lines when parsing blast results

### DIFF
--- a/el_gato/el_gato.py
+++ b/el_gato/el_gato.py
@@ -991,6 +991,9 @@ def blast_remaining_loci(inputs: dict, assembly_file: str, ref: Ref, momps: bool
     inputs["json_out"]['mode_specific'] = blast_dict
 
     for line in result.strip().split('\n'):
+        if not line:
+            continue
+
         bits = line.split()
 
         # Find best match in db


### PR DESCRIPTION
If blast produces empty results, it's possible to get here with an empty string.

That causes the indexing here to fail:
```
locus = "_".join(bits[1].split("_")[:-1])
```

If there's no results we may as well just carry on, the loop logic won't do much (I don't think).